### PR TITLE
Fix case session['_csrf_token'] isn't populated

### DIFF
--- a/lib/cacheable-csrf-token-rails.rb
+++ b/lib/cacheable-csrf-token-rails.rb
@@ -9,7 +9,7 @@ module CacheableCSRFTokenRails
 
       private
       def inject_csrf_token
-        if protect_against_forgery? && token = session['_csrf_token']
+        if protect_against_forgery? && token = form_authenticity_token
           if body_with_token = response.body.gsub!(ApplicationController::TOKEN_PLACEHOLDER, token)
             response.body = body_with_token
           end
@@ -22,7 +22,6 @@ module CacheableCSRFTokenRails
 
       def token_tag(token=nil)
         if token != false && protect_against_forgery?
-          token ||= form_authenticity_token
           tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => ApplicationController::TOKEN_PLACEHOLDER)
         else
           ''


### PR DESCRIPTION
Assume two users visit an action that is setup for caching. If the page is not cached when the first user hits it, the page will be generated for them and `token_tag` creates a csrf token in `session['_csrf_token']`.

As the session var exists, the substitution can be done for the first user.

However, when the second user hits the action it's cached, so `token_tag` won't be called, and therefore won't generate a csrf token for them.

Calling `form_authenticity_token` instead of manually accessing the session object ensures that the token is created for the user, regardless of whether `token_tag`/`csrf_meta_tags` was called during the request.
