### PR TITLE
Changeing namespace of token_tag method

### DIFF
--- a/lib/cacheable-csrf-token-rails.rb
+++ b/lib/cacheable-csrf-token-rails.rb
@@ -17,7 +17,7 @@ module CacheableCSRFTokenRails
       end
     end
 
-    ActionView::Helpers::FormTagHelper.class_eval do
+    ActionView::Helpers::UrlHelper.class_eval do
       alias_method :token_tag_rails, :token_tag
 
       def token_tag(token=nil)


### PR DESCRIPTION
The `token_tag` method has changed scope from `FormTagHelper` to `UrlHelper` in Rails 4. This patch updates the namespace, to allow rails 4 compatability. 
